### PR TITLE
Robustify dictionary sugar

### DIFF
--- a/R/Dictionary.R
+++ b/R/Dictionary.R
@@ -155,7 +155,8 @@ dictionary_retrieve_item = function(self, key) {
 }
 
 dictionary_initialize_item = function(key, obj, cargs) {
-  cargs = insert_named(obj$pars, cargs)
+  cargs = c(cargs[is.na(names2(cargs))],
+    insert_named(obj$pars, cargs[!is.na(names2(cargs))]))
   ii = wf(obj$required_args %nin% names(cargs))
   if (length(ii)) {
     stopf("Need argument '%s' to construct '%s'", obj$required_args[ii], key)

--- a/R/dictionary_sugar.R
+++ b/R/dictionary_sugar.R
@@ -25,19 +25,20 @@
 #' d = Dictionary$new()
 #' d$add("key", item)
 #' dictionary_sugar(d, "key", x = 2)
-dictionary_sugar = function(dict, key, ...) {
+dictionary_sugar = function(dict, .key, ...) {
   assert_class(dict, "Dictionary")
   if (...length() == 0L) {
-    return(dictionary_get(dict, key))
+    return(dictionary_get(dict, .key))
   }
-  dots = assert_list(list(...), names = "unique", .var.name = "additional arguments passed to Dictionary")
+  dots = assert_list(list(...), .var.name = "additional arguments passed to Dictionary")
+  assert_list(dots[!is.na(names2(dots))], names = "unique", .var.name = "named arguments passed to Dictionary")
 
-  obj = dictionary_retrieve_item(dict, key)
+  obj = dictionary_retrieve_item(dict, .key)
 
   # pass args to constructor and remove them
   cargs = get_constructor_formals(obj$value)
-  ii = is.na(dots) | names(dots) %in% cargs
-  instance = assert_r6(dictionary_initialize_item(key, obj, dots[ii]))
+  ii = is.na(names2(dots)) | names2(dots) %in% cargs
+  instance = assert_r6(dictionary_initialize_item(.key, obj, dots[ii]))
   dots = dots[!ii]
 
 

--- a/tests/testthat/test_Dictionary.R
+++ b/tests/testthat/test_Dictionary.R
@@ -60,10 +60,22 @@ test_that("dictionary_cast", {
 })
 
 test_that("dictionary_sugar", {
-  Foo = R6::R6Class("Foo", public = list(x = 0, y = 0, initialize = function(y) self$y = y), cloneable = TRUE)
+  Foo = R6::R6Class("Foo", public = list(x = 0, y = 0, key = 0, initialize = function(y, key = -1) { self$y = y ; self$key = key }), cloneable = TRUE)
   d = Dictionary$new()
   d$add("f1", Foo)
   x = dictionary_sugar(d, "f1", y = 99, x = 1)
   expect_equal(x$x, 1)
   expect_equal(x$y, 99)
+  expect_equal(x$key, -1)
+  x2 = dictionary_sugar(d, "f1", 99, x = 1)
+  expect_equal(x, x2)
+  x2 = dictionary_sugar(d, "f1", x = 1, 99)
+  expect_equal(x, x2)
+
+  x = dictionary_sugar(d, "f1", 1, 99)
+  expect_equal(x$x, 0)
+  expect_equal(x$y, 1)
+  expect_equal(x$key, 99)
+  x2 = dictionary_sugar(d, "f1", key = 99, y = 1)
+  expect_equal(x, x2)
 })


### PR DESCRIPTION
* allow `dictionary_sugar()` with unnamed construction arguments
* use `.key` instead of `key` for key argument, to avoid partial matching with `k = ...`.