### PR TITLE
add logical version require_namespaces

### DIFF
--- a/R/require_namespaces.R
+++ b/R/require_namespaces.R
@@ -9,6 +9,9 @@
 #'   Packages to load.
 #' @param msg (`character(1)`)\cr
 #'   Message to print on error. Use `"%s"` as placeholder for the list of packages.
+#' @param quietly (`logical(1)`)\cr
+#'   If `TRUE` then returns `TRUE` if all packages available, otherwise `FALSE`.
+#'
 #'
 #' @return (named `character()`) of loaded packages (invisibly).
 #' @export
@@ -18,12 +21,18 @@
 #' # catch condition, return missing packages
 #' tryCatch(require_namespaces(c("mlr3misc", "foobaaar")),
 #'   packageNotFoundError = function(e) e$packages)
-require_namespaces = function(pkgs, msg = "The following packages could not be loaded: %s") {
+require_namespaces = function(pkgs, msg = "The following packages could not be loaded: %s",
+                              quietly = FALSE) {
   pkgs = unique(assert_character(pkgs, any.missing = FALSE))
   ii = which(!map_lgl(pkgs, requireNamespace, quietly = TRUE))
+
   if (length(ii)) {
+    if (quietly) return(FALSE)
     msg = sprintf(msg, paste0(pkgs[ii], collapse = ","))
     stop(errorCondition(msg, packages = pkgs[ii], class = "packageNotFoundError"))
+  } else if (quietly) {
+    return(TRUE)
+  } else {
+    invisible(pkgs)
   }
-  invisible(pkgs)
 }

--- a/man/require_namespaces.Rd
+++ b/man/require_namespaces.Rd
@@ -6,7 +6,8 @@
 \usage{
 require_namespaces(
   pkgs,
-  msg = "The following packages could not be loaded: \%s"
+  msg = "The following packages could not be loaded: \%s",
+  quietly = FALSE
 )
 }
 \arguments{
@@ -15,6 +16,9 @@ Packages to load.}
 
 \item{msg}{(\code{character(1)})\cr
 Message to print on error. Use \code{"\%s"} as placeholder for the list of packages.}
+
+\item{quietly}{(\code{logical(1)})\cr
+If \code{TRUE} then returns \code{TRUE} if all packages available, otherwise \code{FALSE}.}
 }
 \value{
 (named \code{character()}) of loaded packages (invisibly).

--- a/tests/testthat/test_require_namespaces.R
+++ b/tests/testthat/test_require_namespaces.R
@@ -8,4 +8,7 @@ test_that("require_namespaces", {
 
   expect_equal(tryCatch(require_namespaces("this_is_not_a_package999"),
     packageNotFoundError = function(e) e$packages), "this_is_not_a_package999")
+
+  expect_true(require_namespaces("mlr3misc", quietly = TRUE))
+  expect_false(require_namespaces("this_is_not_a_package999", quietly = TRUE))
 })


### PR DESCRIPTION
If you hate the idea just close the PR and delete the branch. I just keep re-implementing this in other packages so thought it could be useful to have it globally via mlr3misc.

PR just adds a `quietly` option to `require_namespaces` which means that instead of returning string/error it returns TRUE/FALSE, the advantage is then it can be used in documentation and tests more easily.