### PR TITLE
added multioutput formula

### DIFF
--- a/R/formulate.R
+++ b/R/formulate.R
@@ -4,8 +4,8 @@
 #' Given the left-hand side and right-hand side as character vectors, generates a new
 #' [stats::formula()].
 #'
-#' @param lhs (`character(1)`)\cr
-#'   Left-hand side of formula.
+#' @param lhs (`character()`)\cr
+#'   Left-hand side of formula. Multiple elements will be collapsed with `" + "`.
 #' @param rhs (`character()`)\cr
 #'   Right-hand side of formula. Multiple elements will be collapsed with `" + "`.
 #' @param env (`environment()`)\cr
@@ -23,7 +23,7 @@ formulate = function(lhs = NULL, rhs = NULL, env = NULL) {
   if (length(rhs) == 0L) {
     rhs = "1"
   }
-  f = as.formula(sprintf("%s ~ %s", lhs, paste0(rhs, collapse = " + ")))
+  f = as.formula(sprintf("%s ~ %s", paste0(lhs, collapse = " + "), paste0(rhs, collapse = " + ")))
   environment(f) = env
   f
 }

--- a/man/formulate.Rd
+++ b/man/formulate.Rd
@@ -7,8 +7,8 @@
 formulate(lhs = NULL, rhs = NULL, env = NULL)
 }
 \arguments{
-\item{lhs}{(\code{character(1)})\cr
-Left-hand side of formula.}
+\item{lhs}{(\code{character()})\cr
+Left-hand side of formula. Multiple elements will be collapsed with \code{" + "}.}
 
 \item{rhs}{(\code{character()})\cr
 Right-hand side of formula. Multiple elements will be collapsed with \code{" + "}.}

--- a/tests/testthat/test_formulate.R
+++ b/tests/testthat/test_formulate.R
@@ -7,3 +7,13 @@ test_that("formulate", {
   expect_set_equal(x$lhs, "Species")
   expect_set_equal(x$rhs, c("Sepal.Width", "Petal.Length"))
 })
+
+test_that("formulate_multioutput", {
+  f = formulate(c("Pepal.Width", "Petal.Length"), c("Sepal.Width", "Sepal.Length"))
+  expect_formula(f)
+  expect_null(environment(f))
+
+  x = extract_vars(f)
+  expect_set_equal(x$lhs, c("Pepal.Width", "Petal.Length"))
+  expect_set_equal(x$rhs, c("Sepal.Width", "Sepal.Length"))
+})


### PR DESCRIPTION
`formulate` function is now able to create formulas with multiple targets, e.g.
```
formulate(c("Pepal.Width", "Petal.Length"), c("Sepal.Width", "Sepal.Length"))
> Pepal.Width + Petal.Length ~ Sepal.Width + Sepal.Length
```