### PR TITLE
fix: remove srcref after leanification

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# mlr3misc 0.12.0-9000
+
+* fix: Fixed an important bug that caused serialized objects to be overly large
+when installing mlr3 with `--with-keep.source` (#88)
+
 # mlr3misc 0.12.0
 
 * Added new encapsulation mode `"try"`.

--- a/R/leanify.R
+++ b/R/leanify.R
@@ -43,8 +43,9 @@ leanificate_method = function(cls, fname, env = cls$parent_env) {
   environment(replacingfn) = environment(fn)
 
   function_kind = switch(function_kind_container, public_methods = "public", private_methods = "private", active = "active")
-  # otherwise leanification is not applied properly when installing mlr3 with --with-keep.source
-  # this can cause serialized objects to be unreasonably large
+  # We remove the srcref (which exists when installing with option --with-keep.source) because:
+  # (1) incorrect rendering of leanified functions
+  # (2) use up memory unnecessarily
   origattributes$srcref = NULL
   attributes(replacingfn) = origattributes
   cls$set(function_kind, fname, replacingfn, overwrite = TRUE)

--- a/R/leanify.R
+++ b/R/leanify.R
@@ -43,6 +43,7 @@ leanificate_method = function(cls, fname, env = cls$parent_env) {
   environment(replacingfn) = environment(fn)
 
   function_kind = switch(function_kind_container, public_methods = "public", private_methods = "private", active = "active")
+  origattributes$srcref = NULL
   attributes(replacingfn) = origattributes
   cls$set(function_kind, fname, replacingfn, overwrite = TRUE)
 }

--- a/R/leanify.R
+++ b/R/leanify.R
@@ -43,6 +43,8 @@ leanificate_method = function(cls, fname, env = cls$parent_env) {
   environment(replacingfn) = environment(fn)
 
   function_kind = switch(function_kind_container, public_methods = "public", private_methods = "private", active = "active")
+  # otherwise leanification is not applied properly when installing mlr3 with --with-keep.source
+  # this can cause serialized objects to be unreasonably large
   origattributes$srcref = NULL
   attributes(replacingfn) = origattributes
   cls$set(function_kind, fname, replacingfn, overwrite = TRUE)


### PR DESCRIPTION
When compiling R with `--with-keep.source`, serialized objects were gigantic (and dependent on the loaded packages), see this issue: https://github.com/mlr-org/mlr3misc/issues/88

I tested that when installing mlr3 with `--with-keep.source` with this version of mlr3misc, the problem disappears. 
This also caused the failed workflows in the mlr3book

@berndbischl @mllg @mb706 