### PR TITLE
fix: disable leanfication during documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# mlr3misc 0.12.0-9000
+# mlr3misc 0.13.0-9000
+
+* fix: leanification is disabled when documenting a package
+
+# mlr3misc 0.13.0
 
 * Updated default environment for `crate()` to `topenv()` (#86).
 * Added safe methods for dictionary retrieval (#83)

--- a/R/leanify.R
+++ b/R/leanify.R
@@ -96,6 +96,14 @@ leanify_r6 = function(cls, env = cls$parent_env) {
 #'   always (i.e. skipping no classes).
 #' @export
 leanify_package = function(pkg_env = parent.frame(), skip_if = function(x) FALSE) {
+  # To generate the R6 documentation, roxygen needs access to the srcref (in order to associate methods with method
+  # documentation)
+  # Because our srcrefs are set to NULL during leanification we need to disable it
+  if (grepl("(document|roxygenise|roxygenize)", deparse(as.list(sys.calls()[[1L]])[[1L]]))) {
+    messagef("Skipping leanification for documentation!")
+    return(NULL)
+  }
+
   assert_environment(pkg_env)
   assert_function(skip_if)
 

--- a/man/crate.Rd
+++ b/man/crate.Rd
@@ -4,7 +4,7 @@
 \alias{crate}
 \title{Isolate a Function from its Environment}
 \usage{
-crate(.fn, ..., .parent = .GlobalEnv)
+crate(.fn, ..., .parent = topenv())
 }
 \arguments{
 \item{.fn}{(\verb{function()})\cr
@@ -14,7 +14,7 @@ function to crate}
 The objects, which should be visible inside \code{.fn}.}
 
 \item{.parent}{(\code{environment})\cr
-Parent environment to look up names. Default so the global environment.}
+Parent environment to look up names. Default to \code{\link[=topenv]{topenv()}}.}
 }
 \description{
 Put a function in a "lean" environment that does not carry unnecessary baggage with it (e.g. references to datasets).


### PR DESCRIPTION
mlr3misc 0.13.0 broke documentation with roxygen, this is fixed in this PR. 
