### PR TITLE
feat: add .compile argument to crate function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-# mlr3misc 0.12.0-9000
+# mlr3misc 0.13.0-9000
+
+* Added argument `.compile` to function `crate()` because R disables byte-code
+compilation of functions when changing their enclosing environment
+
+# mlr3misc 0.13.0
 
 * Updated default environment for `crate()` to `topenv()` (#86).
 * Added safe methods for dictionary retrieval (#83)

--- a/R/crate.R
+++ b/R/crate.R
@@ -30,9 +30,10 @@
 #' f()
 crate = function(.fn, ..., .parent = topenv(), .compile = TRUE) {
   assert_flag(.compile)
+  .compile = .compile || is_compiled(.fn)
   nn = map_chr(substitute(list(...)), as.character)[-1L]
   environment(.fn) = list2env(setNames(list(...), nn), parent = .parent)
-  if (.compile || is_compiled(.fn)) {
+  if (.compile) {
     .fn = compiler::cmpfun(.fn)
   }
   return(.fn)

--- a/R/crate.R
+++ b/R/crate.R
@@ -11,6 +11,8 @@
 #'   Parent environment to look up names. Default to [topenv()].
 #' @param .compile (`logical(1)`)\cr
 #'   Whether to jit-compile the function.
+#'   In case the function is already compiled.
+#'   If the input function `.fn` is compiled, this has no effect, and the output function will always be compiled.
 #'
 #' @export
 #' @examples
@@ -27,10 +29,18 @@
 #' f = meta_f(1)
 #' f()
 crate = function(.fn, ..., .parent = topenv(), .compile = TRUE) {
+  assert_flag(.compile)
   nn = map_chr(substitute(list(...)), as.character)[-1L]
   environment(.fn) = list2env(setNames(list(...), nn), parent = .parent)
-  if (.compile) {
+  if (.compile || is_compiled(.fn)) {
     .fn = compiler::cmpfun(.fn)
   }
   return(.fn)
+}
+
+is_compiled = function(x) {
+  tryCatch({
+    capture.output(compiler::disassemble(x))
+    TRUE
+  }, error = function(e) FALSE)
 }

--- a/R/crate.R
+++ b/R/crate.R
@@ -9,6 +9,8 @@
 #'   The objects, which should be visible inside `.fn`.
 #' @param .parent (`environment`)\cr
 #'   Parent environment to look up names. Default to [topenv()].
+#' @param .compile (`logical(1)`)\cr
+#'   Whether to jit-compile the function.
 #'
 #' @export
 #' @examples
@@ -24,8 +26,11 @@
 #' z = 300
 #' f = meta_f(1)
 #' f()
-crate = function(.fn, ..., .parent = topenv()) {
+crate = function(.fn, ..., .parent = topenv(), .compile = TRUE) {
   nn = map_chr(substitute(list(...)), as.character)[-1L]
   environment(.fn) = list2env(setNames(list(...), nn), parent = .parent)
-  .fn
+  if (.compile) {
+    .fn = compiler::cmpfun(.fn)
+  }
+  return(.fn)
 }

--- a/man/crate.Rd
+++ b/man/crate.Rd
@@ -4,7 +4,7 @@
 \alias{crate}
 \title{Isolate a Function from its Environment}
 \usage{
-crate(.fn, ..., .parent = .GlobalEnv)
+crate(.fn, ..., .parent = topenv(), .compile = TRUE)
 }
 \arguments{
 \item{.fn}{(\verb{function()})\cr
@@ -14,7 +14,10 @@ function to crate}
 The objects, which should be visible inside \code{.fn}.}
 
 \item{.parent}{(\code{environment})\cr
-Parent environment to look up names. Default so the global environment.}
+Parent environment to look up names. Default to \code{\link[=topenv]{topenv()}}.}
+
+\item{.compile}{(\code{logical(1)})\cr
+Whether to jit-compile the function.}
 }
 \description{
 Put a function in a "lean" environment that does not carry unnecessary baggage with it (e.g. references to datasets).

--- a/man/crate.Rd
+++ b/man/crate.Rd
@@ -17,7 +17,9 @@ The objects, which should be visible inside \code{.fn}.}
 Parent environment to look up names. Default to \code{\link[=topenv]{topenv()}}.}
 
 \item{.compile}{(\code{logical(1)})\cr
-Whether to jit-compile the function.}
+Whether to jit-compile the function.
+In case the function is already compiled.
+If the input function \code{.fn} is compiled, this has no effect, and the output function will always be compiled.}
 }
 \description{
 Put a function in a "lean" environment that does not carry unnecessary baggage with it (e.g. references to datasets).

--- a/tests/testthat/test_crate.R
+++ b/tests/testthat/test_crate.R
@@ -12,3 +12,8 @@ test_that("crate", {
   f = meta_f(1)
   expect_equal(f(), c(1, 200, 300))
 })
+
+test_that("compilation works", {
+  expect_error(compiler::disassemble(crate(function() NULL, .compile = FALSE)), regexp = "function is not compiled")
+  expect_error(compiler::disassemble(crate(function() NULL, .compile = TRUE)), regexp = NA)
+})

--- a/tests/testthat/test_crate.R
+++ b/tests/testthat/test_crate.R
@@ -14,11 +14,7 @@ test_that("crate", {
 })
 
 test_that("compilation works", {
-  expect_error(compiler::disassemble(crate(function() NULL, .compile = FALSE)), regexp = "function is not compiled")
-  expect_error(compiler::disassemble(crate(function() NULL, .compile = TRUE)), regexp = NA)
-
-  f = function() NULL
-  fc = compiler::cmpfun(f)
-
-  expect_true(is_compiled(fc))
+  expect_false(is_compiled(crate(function() NULL, .compile = FALSE)))
+  expect_true(is_compiled(crate(function() NULL, .compile = TRUE)))
+  expect_true(is_compiled(crate(compiler::cmpfun(function() NULL), .compile = FALSE)))
 })

--- a/tests/testthat/test_crate.R
+++ b/tests/testthat/test_crate.R
@@ -16,4 +16,9 @@ test_that("crate", {
 test_that("compilation works", {
   expect_error(compiler::disassemble(crate(function() NULL, .compile = FALSE)), regexp = "function is not compiled")
   expect_error(compiler::disassemble(crate(function() NULL, .compile = TRUE)), regexp = NA)
+
+  f = function() NULL
+  fc = compiler::cmpfun(f)
+
+  expect_true(is_compiled(fc))
 })


### PR DESCRIPTION
R disables jit-compilation of functions when changing their environment.

Resolves Issue #94

* [x] if byte code compiled function should go in it should always be compiled
* [x] Why does this happen?
* https://github.com/wch/r-source/blob/94a6ef1b189379c10c9e651d83a098c78ecd6a76/src/main/builtin.c#L324