### PR TITLE
feat: warn when installing packages with srcrefs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mlr3misc
 Title: Helper Functions for 'mlr3'
-Version: 0.12.0-9000
+Version: 0.13.0-9000
 Authors@R: c(
     person("Michel", "Lang", , "michellang@gmail.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0001-9754-0393")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Config/testthat/parallel: true
 Encoding: UTF-8
 NeedsCompilation: yes
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.2.3.9000
 Collate:
     'Dictionary.R'
     'named_list.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Loading `mlr3misc` now gives a warning when the package is being installed
   with source references, which can lead to unreasonable memory usage.
+  This can be disabled using option `"mlr3misc.warn_srcref"`
 
 # mlr3misc 0.13.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# mlr3misc 0.12.0-9000
+# mlr3misc 0.13.0-9000
+
+* Warn when the package is installed with source references.
+
+# mlr3misc 0.13.0
 
 * Updated default environment for `crate()` to `topenv()` (#86).
 * Added safe methods for dictionary retrieval (#83)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3misc 0.13.0-9000
 
-* Warn when the package is installed with source references.
+* Loading `mlr3misc` now gives a warning when the package is being installed
+  with source references, which can lead to unreasonable memory usage.
 
 # mlr3misc 0.13.0
 

--- a/R/leanify.R
+++ b/R/leanify.R
@@ -106,3 +106,8 @@ leanify_package = function(pkg_env = parent.frame(), skip_if = function(x) FALSE
     }
   }
 }
+
+has_srcref = function(fn) {
+  # we could also just inspect the attributes but this would evaluate the promise
+  !identical(as.character(substitute(lines, attr(attr(fn, "srcref"), "srcfile")$original)), "lines")
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,8 +15,8 @@
 .onLoad = function(libname, pkgname) {
   # nocov start
   if (has_srcref(ids) && getOption("mlr3misc.warn_srcref", TRUE)) {
-    warningf(paste0("It looks like you are installing packages with the '--with-keep.source' flag which is discouraged.\n", # nolint
-      "You can find more information on this on the FAQ section of our website: https://mlr-org.com/faq.html",
+    warningf(paste0("It looks like you are installing packages with the '--with-keep.source' flag, which is discouraged.\n", # nolint
+      "You can find more information on this on the FAQ section of our website: https://mlr-org.com/faq.html\n",
       "This warning can be disabled by setting the 'mlr3misc.warn_srcref' option to FALSE.\n"))
   }
   backports::import(pkgname)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,9 +5,19 @@
 #' @importFrom R6 R6Class is.R6
 #' @importFrom digest digest
 #' @importFrom methods formalArgs hasArg
+#'
+#' @section Package Options:
+#' * `"mlr3misc.warn_srcref"`:
+#'   Disable giving a warning during package loading when packages seem to be installed with the `"--with-keep.source"`
+#'   option by setting this option to `FALSE`. Defaults to `TRUE`.
 "_PACKAGE"
 
 .onLoad = function(libname, pkgname) {
   # nocov start
+  if (has_srcref(ids) && getOption("mlr3misc.warn_srcref", TRUE)) {
+    warningf(paste0("It looks like you are installing packages with the '--with-keep.source' flag which is discouraged.\n", # nolint
+      "You can find more information on this on the FAQ section of our website: https://mlr-org.com/faq.html",
+      "This warning can be disabled by setting the 'mlr3misc.warn_srcref' option to FALSE.\n"))
+  }
   backports::import(pkgname)
 } # nocov end

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,7 @@
 .onLoad = function(libname, pkgname) {
   # nocov start
   if (has_srcref(ids) && getOption("mlr3misc.warn_srcref", TRUE)) {
-    warningf(paste0("It looks like you are installing packages with the '--with-keep.source' flag, which is discouraged.\n", # nolint
+    warningf(paste0("It looks like you installed packages with the '--with-keep.source' flag, which is discouraged.\n", # nolint
       "You can find more information on this on the FAQ section of our website: https://mlr-org.com/faq.html\n",
       "This warning can be disabled by setting the 'mlr3misc.warn_srcref' option to FALSE.\n"))
   }

--- a/man/crate.Rd
+++ b/man/crate.Rd
@@ -4,7 +4,7 @@
 \alias{crate}
 \title{Isolate a Function from its Environment}
 \usage{
-crate(.fn, ..., .parent = .GlobalEnv)
+crate(.fn, ..., .parent = topenv())
 }
 \arguments{
 \item{.fn}{(\verb{function()})\cr
@@ -14,7 +14,7 @@ function to crate}
 The objects, which should be visible inside \code{.fn}.}
 
 \item{.parent}{(\code{environment})\cr
-Parent environment to look up names. Default so the global environment.}
+Parent environment to look up names. Default to \code{\link[=topenv]{topenv()}}.}
 }
 \description{
 Put a function in a "lean" environment that does not carry unnecessary baggage with it (e.g. references to datasets).

--- a/man/mlr3misc-package.Rd
+++ b/man/mlr3misc-package.Rd
@@ -10,6 +10,15 @@
 
 Frequently used helper functions and assertions used in 'mlr3' and its companion packages. Comes with helper functions for functional programming, for printing, to work with 'data.table', as well as some generally useful 'R6' classes. This package also supersedes the package 'BBmisc'.
 }
+\section{Package Options}{
+
+\itemize{
+\item \code{"mlr3misc.warn_srcref"}:
+Disable giving a warning during package loading when packages seem to be installed with the \code{"--with-keep.source"}
+option by setting this option to \code{FALSE}. Defaults to \code{TRUE}.
+}
+}
+
 \seealso{
 Useful links:
 \itemize{


### PR DESCRIPTION
When installing packages with source references and configuring objects with parameters that are functions, objects can be gigantic. Here we heuristically check whether mlr3misc is installed with srcrefs and warn if this is the case. 
Note that we don't simply check for the presence of srcrefs in the attributes to avoid evaluating the promise.