### PR TITLE
fix keep_in_bounds so we dont use internal API

### DIFF
--- a/src/keep_in_bounds.c
+++ b/src/keep_in_bounds.c
@@ -1,48 +1,31 @@
-#define R_NO_REMAP
 #include <R.h>
 #include <Rinternals.h>
 
-SEXP c_keep_in_bounds(SEXP in, SEXP lower, SEXP upper) {
-    const int * x = INTEGER(in);
-    const int ll = INTEGER(lower)[0];
-    const int lu = INTEGER(upper)[0];
-    const R_xlen_t n = Rf_xlength(in);
-    R_xlen_t i;
+SEXP c_keep_in_bounds(SEXP s_in, SEXP s_lower, SEXP s_upper) {
+    const int *x = INTEGER(s_in);
+    const int ll = asInteger(s_lower);
+    const int lu = asInteger(s_upper);
+    const R_xlen_t n = LENGTH(s_in);
+    R_xlen_t i, j;
 
-    // fast-forward to first element not in bounds
+    // count the number of elements within bounds
+    int count = 0;
+    for (i = 0; i < n; i++)
+        if (x[i] != NA_INTEGER && x[i] >= ll && x[i] <= lu) count++;
+
+    // if all ok, immediatly return without alloc and copy
+    if (count == n) return(s_in);
+
+    // create a new vector to store the filtered elements
+    SEXP s_out = PROTECT(allocVector(REALSXP, count));
+    double *out = REAL(s_out);
+
+    // Copy the elements within bounds to the new vector
+    j = 0;
     for (i = 0; i < n; i++) {
-        if (x[i] == NA_INTEGER || x[i] < ll || x[i] > lu) {
-            break;
-        }
+        if (x[i] != NA_INTEGER && x[i] >= ll && x[i] <= lu)
+            out[j++] = x[i];
     }
-
-    // everything ok, in == out
-    if (i == n) {
-        return(in);
-    }
-
-    // allocate output vector
-    SEXP out = PROTECT(Rf_allocVector(INTSXP, n));
-    int * y = INTEGER(out);
-    R_xlen_t j;
-
-    // copy everything up to the first element out of bounds
-    for (j = 0; j < i; j++) {
-        y[j] = x[j];
-    }
-
-    // process remaining elements
-    for (i = i + 1; i < n; i++) {
-        if (x[i] != NA_INTEGER && x[i] >= ll && x[i] <= lu) {
-            y[j] = x[i];
-            j++;
-        }
-    }
-
-    // resize the vector to the right length
-    SETLENGTH(out, j);
-
-    // unprotect + return
     UNPROTECT(1);
-    return out;
+    return s_out;
 }


### PR DESCRIPTION
apparently a call to SETLENGTH is considered "internal"

we checked that that code is also neither used in mlr3, paradox and mlr3tune, so we probably don't need the function anyway (?)