### PR TITLE
`dictionary_sugar_get` does string comparison with other given dictionaries for error message

### DIFF
--- a/R/Dictionary.R
+++ b/R/Dictionary.R
@@ -177,15 +177,18 @@ Dictionary = R6::R6Class("Dictionary",
   )
 )
 
+# ADD .dicts_suggest
 dictionary_get = function(self, key, ...) {
   obj = dictionary_retrieve_item(self, key)
   dots = assert_list(list(...), names = "unique", .var.name = "arguments passed to Dictionary")
   dictionary_initialize_item(key, obj, dots)
 }
 
+# ADD .dicts_suggest
 dictionary_retrieve_item = function(self, key) {
   obj = get0(key, envir = self$items, inherits = FALSE, ifnotfound = NULL)
   if (is.null(obj)) {
+    # ADD did_you_mean_dicts here?
     stopf("Element with key '%s' not found in %s!%s", key, class(self)[1L], did_you_mean(key, self$keys()))
   }
   obj

--- a/R/Dictionary.R
+++ b/R/Dictionary.R
@@ -177,19 +177,18 @@ Dictionary = R6::R6Class("Dictionary",
   )
 )
 
-# ADD .dicts_suggest
-dictionary_get = function(self, key, ...) {
-  obj = dictionary_retrieve_item(self, key)
+dictionary_get = function(self, key, ..., .dicts_suggest) {
+  obj = dictionary_retrieve_item(self, key, .dicts_suggest = .dicts_suggest)
   dots = assert_list(list(...), names = "unique", .var.name = "arguments passed to Dictionary")
   dictionary_initialize_item(key, obj, dots)
 }
 
-# ADD .dicts_suggest
-dictionary_retrieve_item = function(self, key) {
+dictionary_retrieve_item = function(self, key, dicts_suggest) {
   obj = get0(key, envir = self$items, inherits = FALSE, ifnotfound = NULL)
   if (is.null(obj)) {
-    # ADD did_you_mean_dicts here?
-    stopf("Element with key '%s' not found in %s!%s", key, class(self)[1L], did_you_mean(key, self$keys()))
+    stopf("Element with key '%s' not found in %s!%s%s", key, class(self)[1L],
+          did_you_mean(key, self$keys()),
+          did_you_mean_dicts(key, dicts_suggest))
   }
   obj
 }

--- a/R/Dictionary.R
+++ b/R/Dictionary.R
@@ -178,7 +178,7 @@ Dictionary = R6::R6Class("Dictionary",
 )
 
 dictionary_get = function(self, key, ..., .dicts_suggest) {
-  obj = dictionary_retrieve_item(self, key, .dicts_suggest = .dicts_suggest)
+  obj = dictionary_retrieve_item(self, key, .dicts_suggest)
   dots = assert_list(list(...), names = "unique", .var.name = "arguments passed to Dictionary")
   dictionary_initialize_item(key, obj, dots)
 }
@@ -208,7 +208,6 @@ dictionary_initialize_item = function(key, obj, cargs = list()) {
     constructor
   }
 }
-
 
 #' @export
 as.data.table.Dictionary = function(x, ...) {

--- a/R/dictionary_sugar.R
+++ b/R/dictionary_sugar.R
@@ -32,18 +32,22 @@
 #' d = Dictionary$new()
 #' d$add("key", item)
 #' dictionary_sugar_get(d, "key", x = 2)
-dictionary_sugar_get = function(dict, .key, ...) {
+dictionary_sugar_get = function(dict, .key, .dicts_suggest, ...) {
   assert_class(dict, "Dictionary")
   if (missing(.key)) {
     return(dict)
   }
   assert_string(.key)
+  # ASSERT .dicts_suggest
+  # either class Dictionary or list of Dictionaries?
   if (...length() == 0L) {
+    # ADD .dicts_suggest
     return(dictionary_get(dict, .key))
   }
   dots = assert_list(list(...), .var.name = "additional arguments passed to Dictionary")
   assert_list(dots[!is.na(names2(dots))], names = "unique", .var.name = "named arguments passed to Dictionary")
 
+  # ADD .dicts_suggest
   obj = dictionary_retrieve_item(dict, .key)
   if (length(dots) == 0L) {
     return(assert_r6(dictionary_initialize_item(.key, obj)))
@@ -54,7 +58,6 @@ dictionary_sugar_get = function(dict, .key, ...) {
   ii = is.na(names2(dots)) | names2(dots) %in% constructor_args
   instance = assert_r6(dictionary_initialize_item(.key, obj, dots[ii]))
   dots = dots[!ii]
-
 
   # set params in ParamSet
   if (length(dots) && exists("param_set", envir = instance, inherits = FALSE)) {
@@ -94,6 +97,7 @@ dictionary_sugar_mget = function(dict, .keys, ...) {
   if (missing(.keys)) {
     return(dict)
   }
+  # ADD .dicts_suggest
   objs = lapply(.keys, dictionary_sugar_get, dict = dict, ...)
   if (!is.null(names(.keys))) {
     nn = names2(.keys)
@@ -132,10 +136,10 @@ fields = function(x) {
 #' @title A Quick Way to Initialize Objects from Dictionaries with Incremented ID
 #'
 #' @description
-#' Covenience wrapper around [dictionary_sugar_get] and [dictionary_sugar_mget] to allow easier avoidance of of ID
+#' Covenience wrapper around [dictionary_sugar_get] and [dictionary_sugar_mget] to allow easier avoidance of ID
 #' clashes which is useful when the same object is used multiple times and the ids have to be unique.
 #' Let `<key>` be the key of the object to retrieve. When passing the `<key>_<n>` to this
-#' function, where `<n>` is any natural numer, the object with key `<key>` is retrieved and the
+#' function, where `<n>` is any natural number, the object with key `<key>` is retrieved and the
 #' suffix `_<n>` is appended to the id after the object is constructed.
 #'
 #' @param dict ([Dictionary])\cr
@@ -166,12 +170,14 @@ fields = function(x) {
 dictionary_sugar_inc_get = function(dict, .key, ...) {
   m = regexpr("_\\d+$", .key)
   if (attr(m, "match.length") == -1L)  {
+    # ADD .dicts_suggest
     return(dictionary_sugar_get(dict = dict, .key = .key, ...))
   }
   assert_true(!methods::hasArg("id"))
   split = regmatches(.key, m, invert = NA)[[1L]]
   newkey = split[[1L]]
   suffix = split[[2L]]
+  # ADD .dicts_suggest
   obj = dictionary_sugar_get(dict = dict, .key = newkey, ...)
   obj$id = paste0(obj$id, suffix)
   obj
@@ -181,6 +187,7 @@ dictionary_sugar_inc_get = function(dict, .key, ...) {
 #' @rdname dictionary_sugar_inc_get
 #' @export
 dictionary_sugar_inc_mget = function(dict, .keys, ...) {
+  # ADD .dicts_suggest
   objs = lapply(.keys, dictionary_sugar_inc_get, dict = dict, ...)
   if (!is.null(names(.keys))) {
     nn = names2(.keys)

--- a/R/dictionary_sugar.R
+++ b/R/dictionary_sugar.R
@@ -182,7 +182,6 @@ dictionary_sugar_inc_get = function(dict, .key, ..., .dicts_suggest = NULL) {
 #' @rdname dictionary_sugar_inc_get
 #' @export
 dictionary_sugar_inc_mget = function(dict, .keys, ..., .dicts_suggest = NULL) {
-  # ADD .dicts_suggest
   objs = lapply(.keys, dictionary_sugar_inc_get, dict = dict, ..., .dicts_suggest = .dicts_suggest)
   if (!is.null(names(.keys))) {
     nn = names2(.keys)

--- a/R/did_you_mean.R
+++ b/R/did_you_mean.R
@@ -22,3 +22,15 @@ did_you_mean = function(str, candidates) {
   }
   sprintf(" Did you mean %s?", str_collapse(suggested, quote = "'", sep = " / "))
 }
+
+# write new function: did_you_mean_dicts
+# extracts keys from dicts
+# passes this to same logic as did_you_mean (can't call directioly, bc of the "Did you mean?" everytime)
+# Wraps results according to the dictionary, i.e. "po(%s)" or some such
+# Returns string with full message
+did_you_mean_dicts = function(key, dicts) {
+  # ASSERTIONS
+  # maybe not necessary; did_you_mean doesn't and should be checked higher up anyway?
+
+
+}

--- a/tests/testthat/test_Dictionary.R
+++ b/tests/testthat/test_Dictionary.R
@@ -125,3 +125,24 @@ test_that("#115", {
   d$add("a", function() A$new())
   expect_error(dictionary_sugar_get(d, "a", y = 10), "Did you mean")
 })
+
+test_that("similar entries in other dictionaries", {
+  obj = R6Class("A", public = list(x = NULL))
+
+  d = Dictionary$new()
+  d$add("abc", obj)
+
+  d_lookup1 = Dictionary$new()
+  d_lookup1$add("cde", obj)
+
+  expect_error(dictionary_sugar_get(d, "cde", .dicts_suggest = list("lookup1" = d_lookup1)), "Similar entries in other dictionaries")
+
+  d_lookup2 = Dictionary$new()
+  d_lookup2$add("bcd", obj)
+
+  # Dictionaries ordered by closest match per dictionary
+  expect_error(
+    dictionary_sugar_get(d, "cde", .dicts_suggest = list("lookup1" = d_lookup1, "lookup2" = d_lookup2)),
+    "Similar entries in other dictionaries.*lookup1.*lookup2"
+  )
+})


### PR DESCRIPTION
Addresses https://github.com/mlr-org/mlr3pipelines/issues/717

Through this, we can pass a list of dictionaries (`.dicts_suggest`) to `dictionary_sugar_get(dict, .key, ..., .dicts_suggest)` which are checked for close matches to `.key` if `.key` was not found in the dictionary `dict`. Close matches are then listed in the error message. 
