### PR TITLE
fix: add space after comma in `require_namespaces()`

### DIFF
--- a/R/require_namespaces.R
+++ b/R/require_namespaces.R
@@ -30,7 +30,7 @@ require_namespaces = function(pkgs, msg = "The following packages could not be l
     if (quietly) {
       return(FALSE)
     }
-    msg = sprintf(msg, paste0(pkgs[ii], collapse = ","))
+    msg = sprintf(msg, toString(pkgs[ii]))
     stop(errorCondition(msg, packages = pkgs[ii], class = "packageNotFoundError"))
   } else if (quietly) {
     return(TRUE)


### PR DESCRIPTION
Surely, there should be a space between each package?