### PR TITLE
feat(error handling): support for error classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,9 @@
 * Added helper `cat_cli()`.
 * fix: default `dicts_suggest = NULL` for `dictionary_get_item()` and `dictionary_retrieve_item()` for backward compatibility.
 * fix a bug in `dictionary_sugar_inc_get`
-* Functions `messagef()`, `warningf()` and `stopf()` now have a `class` argument and also add
-  the additional class `mlr3message`, `mlr3warning` and `mlr3error`, respectively.
+* Functions `warningf()` and `stopf()` now have a `class` argument and also add
+  the additional class `mlr3warning` and `mlr3error`, respectively.
+  The condition object now also includes the call.
 
 # mlr3misc 0.16.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 * Added helper `cat_cli()`.
 * fix: default `dicts_suggest = NULL` for `dictionary_get_item()` and `dictionary_retrieve_item()` for backward compatibility.
 * fix a bug in `dictionary_sugar_inc_get`
+* Functions `messagef()`, `warningf()` and `stopf()` now have a `class` argument and also add
+  the additional class `mlr3message`, `mlr3warning` and `mlr3error`, respectively.
 
 # mlr3misc 0.16.0
 

--- a/R/printf.R
+++ b/R/printf.R
@@ -4,6 +4,21 @@
 #' `catf()`, `messagef()`, `warningf()` and `stopf()` are wrappers around [base::cat()],
 #' [base::message()], [base::warning()] and [base::stop()], respectively.
 #'
+#' @section Errors and Warnings:
+#' Errors and warnings get the classes `mlr3{error, warning}` and also inherit from
+#' `simple{Error, Warning}`.
+#' It is possible to give errors and warnings their own class via the `class` argument.
+#' Doing this, allows to suppress selective conditions via caling handlers, see e.g.
+#' [`globalCallingHandlers`].
+#'
+#' When a function throws such a condition that the user might want to disable,
+#' a section *Errors and Warnings* should be included in the function documention,
+#' describing the condition and its class.
+#'
+#' @details
+#' For leanified R6 classes, the call included in the condition is the method call
+#' and not the call into the leanified method.
+#'
 #' @param msg (`character(1)`)\cr
 #'   Format string passed to [base::sprintf()].
 #' @param file (`character(1)`)\cr
@@ -17,7 +32,7 @@
 #'   If wrapping is enabled, all whitespace characters (`[[:space:]]`) are converted to spaces,
 #'   and consecutive spaces are converted to a single space.
 #' @param class (`character()`)\cr
-#'   Class of the condition.
+#'   Class of the condition (for errors and warnings).
 #'
 #' @name printf
 #' @examples
@@ -52,16 +67,13 @@ catf = function(msg, ..., file = "", wrap = FALSE) {
 #' @export
 #' @rdname printf
 messagef = function(msg, ..., wrap = FALSE, class = NULL) {
-  class <- c(class, c("mlr3message", "message", "condition"))
-  message = str_wrap(sprintf(msg, ...), width = wrap)
-  call = sys_call_unleanified()
-  message(structure(list(message = as.character(message), call = call), class = class))
+  message(str_wrap(sprintf(msg, ...), width = wrap))
 }
 
 #' @export
 #' @rdname printf
 warningf = function(msg, ..., wrap = FALSE, class = NULL) {
-  class <- c(class, c("mlr3warning", "warning", "condition"))
+  class <- c(class, c("mlr3warning", "simpleWarning", "warning", "condition"))
   message = str_wrap(sprintf(msg, ...), width = wrap)
   call = sys_call_unleanified()
   warning(structure(list(message = as.character(message), call = call), class = class))
@@ -70,7 +82,7 @@ warningf = function(msg, ..., wrap = FALSE, class = NULL) {
 #' @export
 #' @rdname printf
 stopf = function(msg, ..., wrap = FALSE, class = NULL) {
-  class <- c(class, c("mlr3error", "error", "condition"))
+  class <- c(class, c("mlr3error", "simpleError", "error", "condition"))
   message = str_wrap(sprintf(msg, ...), width = wrap)
   call = sys_call_unleanified()
   stop(structure(list(message = as.character(message), call = call), class = class))
@@ -80,7 +92,7 @@ sys_call_unleanified = function(which = -2) {
   # when we throw an error in learner$predict(task), we want don't want to see the call
   # .__Learner__predict(self = self, ...), but learner$predict(task)
   call = sys.call(which)
-  if (grepl("^\\.__(.*)__", as.character(call[1]))) {
+  if (!is.null(call) && grepl("^\\.__(.*)__", as.character(call[1]))) {
     return(sys.call(which - 1))
   }
   return(call)

--- a/R/printf.R
+++ b/R/printf.R
@@ -17,6 +17,8 @@
 #'   If set to `FALSE`, wrapping is disabled (default).
 #'   If wrapping is enabled, all whitespace characters (`[[:space:]]`) are converted to spaces,
 #'   and consecutive spaces are converted to a single space.
+#' @param class (`character()`)\cr
+#'   Class of the condition.
 #'
 #' @name printf
 #' @examples
@@ -41,6 +43,7 @@ str_wrap = function(str, width = FALSE) {
   paste0(strwrap(gsub("[[:space:]]+", " ", str), width = width), collapse = "\n")
 }
 
+
 #' @export
 #' @rdname printf
 catf = function(msg, ..., file = "", wrap = FALSE) {
@@ -49,18 +52,24 @@ catf = function(msg, ..., file = "", wrap = FALSE) {
 
 #' @export
 #' @rdname printf
-messagef = function(msg, ..., wrap = FALSE) {
-  message(str_wrap(sprintf(msg, ...), width = wrap))
+messagef = function(msg, ..., wrap = FALSE, class = NULL) {
+  class <- c(class, c("mlr3message", "simpleMessage", "message", "condition"))
+  message = str_wrap(sprintf(msg, ...), width = wrap)
+  message(structure(list(message = as.character(message), call = call), class = class))
 }
 
 #' @export
 #' @rdname printf
-warningf = function(msg, ..., wrap = FALSE) {
-  warning(simpleWarning(str_wrap(sprintf(msg, ...), width = wrap), call = NULL))
+warningf = function(msg, ..., wrap = FALSE, class = NULL) {
+  class <- c(class, c("mlr3warning", "simpleWarning", "warning", "condition"))
+  message = str_wrap(sprintf(msg, ...), width = wrap)
+  warning(structure(list(message = as.character(message), call = call), class = class))
 }
 
 #' @export
 #' @rdname printf
-stopf = function(msg, ..., wrap = FALSE) {
-  stop(simpleError(str_wrap(sprintf(msg, ...), width = wrap), call = NULL))
+stopf = function(msg, ..., wrap = FALSE, class = NULL) {
+  class <- c(class, c("mlr3error", "simpleError", "error", "condition"))
+  message = str_wrap(sprintf(msg, ...), width = wrap)
+  stop(structure(list(message = as.character(message), call = call), class = class))
 }

--- a/R/printf.R
+++ b/R/printf.R
@@ -3,7 +3,6 @@
 #' @description
 #' `catf()`, `messagef()`, `warningf()` and `stopf()` are wrappers around [base::cat()],
 #' [base::message()], [base::warning()] and [base::stop()], respectively.
-#' The call is not included for warnings and errors.
 #'
 #' @param msg (`character(1)`)\cr
 #'   Format string passed to [base::sprintf()].
@@ -53,23 +52,36 @@ catf = function(msg, ..., file = "", wrap = FALSE) {
 #' @export
 #' @rdname printf
 messagef = function(msg, ..., wrap = FALSE, class = NULL) {
-  class <- c(class, c("mlr3message", "simpleMessage", "message", "condition"))
+  class <- c(class, c("mlr3message", "message", "condition"))
   message = str_wrap(sprintf(msg, ...), width = wrap)
+  call = sys_call_unleanified()
   message(structure(list(message = as.character(message), call = call), class = class))
 }
 
 #' @export
 #' @rdname printf
 warningf = function(msg, ..., wrap = FALSE, class = NULL) {
-  class <- c(class, c("mlr3warning", "simpleWarning", "warning", "condition"))
+  class <- c(class, c("mlr3warning", "warning", "condition"))
   message = str_wrap(sprintf(msg, ...), width = wrap)
+  call = sys_call_unleanified()
   warning(structure(list(message = as.character(message), call = call), class = class))
 }
 
 #' @export
 #' @rdname printf
 stopf = function(msg, ..., wrap = FALSE, class = NULL) {
-  class <- c(class, c("mlr3error", "simpleError", "error", "condition"))
+  class <- c(class, c("mlr3error", "error", "condition"))
   message = str_wrap(sprintf(msg, ...), width = wrap)
+  call = sys_call_unleanified()
   stop(structure(list(message = as.character(message), call = call), class = class))
+}
+
+sys_call_unleanified = function(which = -2) {
+  # when we throw an error in learner$predict(task), we want don't want to see the call
+  # .__Learner__predict(self = self, ...), but learner$predict(task)
+  call = sys.call(which)
+  if (grepl("^\\.__(.*)__", as.character(call[1]))) {
+    return(sys.call(which - 1))
+  }
+  return(call)
 }

--- a/R/printf.R
+++ b/R/printf.R
@@ -8,7 +8,7 @@
 #' Errors and warnings get the classes `mlr3{error, warning}` and also inherit from
 #' `simple{Error, Warning}`.
 #' It is possible to give errors and warnings their own class via the `class` argument.
-#' Doing this, allows to suppress selective conditions via caling handlers, see e.g.
+#' Doing this, allows to suppress selective conditions via calling handlers, see e.g.
 #' [`globalCallingHandlers`].
 #'
 #' When a function throws such a condition that the user might want to disable,

--- a/man/mlr_callbacks.Rd
+++ b/man/mlr_callbacks.Rd
@@ -5,7 +5,7 @@
 \alias{mlr_callbacks}
 \title{Dictionary of Callbacks}
 \format{
-An object of class \code{DictionaryCallbacks} (inherits from \code{Dictionary}, \code{R6}) of length 13.
+An object of class \code{DictionaryCallbacks} (inherits from \code{Dictionary}, \code{R6}) of length 12.
 }
 \usage{
 mlr_callbacks

--- a/man/printf.Rd
+++ b/man/printf.Rd
@@ -49,7 +49,7 @@ and not the call into the leanified method.
 Errors and warnings get the classes \verb{mlr3\{error, warning\}} and also inherit from
 \verb{simple\{Error, Warning\}}.
 It is possible to give errors and warnings their own class via the \code{class} argument.
-Doing this, allows to suppress selective conditions via caling handlers, see e.g.
+Doing this, allows to suppress selective conditions via calling handlers, see e.g.
 \code{\link{globalCallingHandlers}}.
 
 When a function throws such a condition that the user might want to disable,

--- a/man/printf.Rd
+++ b/man/printf.Rd
@@ -34,12 +34,29 @@ If wrapping is enabled, all whitespace characters (\verb{[[:space:]]}) are conve
 and consecutive spaces are converted to a single space.}
 
 \item{class}{(\code{character()})\cr
-Class of the condition.}
+Class of the condition (for errors and warnings).}
 }
 \description{
 \code{catf()}, \code{messagef()}, \code{warningf()} and \code{stopf()} are wrappers around \code{\link[base:cat]{base::cat()}},
 \code{\link[base:message]{base::message()}}, \code{\link[base:warning]{base::warning()}} and \code{\link[base:stop]{base::stop()}}, respectively.
 }
+\details{
+For leanified R6 classes, the call included in the condition is the method call
+and not the call into the leanified method.
+}
+\section{Errors and Warnings}{
+
+Errors and warnings get the classes \verb{mlr3\{error, warning\}} and also inherit from
+\verb{simple\{Error, Warning\}}.
+It is possible to give errors and warnings their own class via the \code{class} argument.
+Doing this, allows to suppress selective conditions via caling handlers, see e.g.
+\code{\link{globalCallingHandlers}}.
+
+When a function throws such a condition that the user might want to disable,
+a section \emph{Errors and Warnings} should be included in the function documention,
+describing the condition and its class.
+}
+
 \examples{
 messagef("
   This is a rather long \%s

--- a/man/printf.Rd
+++ b/man/printf.Rd
@@ -39,7 +39,6 @@ Class of the condition.}
 \description{
 \code{catf()}, \code{messagef()}, \code{warningf()} and \code{stopf()} are wrappers around \code{\link[base:cat]{base::cat()}},
 \code{\link[base:message]{base::message()}}, \code{\link[base:warning]{base::warning()}} and \code{\link[base:stop]{base::stop()}}, respectively.
-The call is not included for warnings and errors.
 }
 \examples{
 messagef("

--- a/man/printf.Rd
+++ b/man/printf.Rd
@@ -10,11 +10,11 @@
 \usage{
 catf(msg, ..., file = "", wrap = FALSE)
 
-messagef(msg, ..., wrap = FALSE)
+messagef(msg, ..., wrap = FALSE, class = NULL)
 
-warningf(msg, ..., wrap = FALSE)
+warningf(msg, ..., wrap = FALSE, class = NULL)
 
-stopf(msg, ..., wrap = FALSE)
+stopf(msg, ..., wrap = FALSE, class = NULL)
 }
 \arguments{
 \item{msg}{(\code{character(1)})\cr
@@ -32,6 +32,9 @@ If set to \code{TRUE}, the width defaults to \code{0.9 * getOption("width")}.
 If set to \code{FALSE}, wrapping is disabled (default).
 If wrapping is enabled, all whitespace characters (\verb{[[:space:]]}) are converted to spaces,
 and consecutive spaces are converted to a single space.}
+
+\item{class}{(\code{character()})\cr
+Class of the condition.}
 }
 \description{
 \code{catf()}, \code{messagef()}, \code{warningf()} and \code{stopf()} are wrappers around \code{\link[base:cat]{base::cat()}},

--- a/tests/testthat/test_printf.R
+++ b/tests/testthat/test_printf.R
@@ -21,12 +21,14 @@ test_that("warningf", {
   f = function() warningf("123")
   # "Warning: " not caught by gives_warning
   expect_warning(f(), "123")
+  expect_warning(warningf("abc"), "abc")
 })
 
 test_that("stopf", {
   expect_error(stopf("xxx%ixxx", 123), "xxx123xxx")
   f = function() stopf("123")
   expect_error(f(), "123")
+  expect_error(stopf("abc"), "abc")
 })
 
 test_that("non-leanified call is printed", {

--- a/tests/testthat/test_printf.R
+++ b/tests/testthat/test_printf.R
@@ -28,3 +28,23 @@ test_that("stopf", {
   f = function() stopf("123")
   expect_error(f(), "123")
 })
+
+test_that("non-leanified call is printed", {
+  A = R6Class("A", public = list(warn = function() warningf("test warning")))
+  leanify_r6(A)
+  a = A$new()
+
+  tryCatch(a$warn(),
+    warning = function(w) {
+      expect_equal(w$call, quote(a$warn()))
+    }
+  )
+
+  f = function() warningf("test warning")
+
+  tryCatch(f(),
+    warning = function(w) {
+      expect_equal(w$call, quote(f()))
+    }
+  )
+})


### PR DESCRIPTION
**Summary**

We changed the classes for the conditions and now also include the call in all condition objects.

Previously we did not add the call to the condition objects, so this meant that the error/warning messages did not include the function call when using `stopf` etc. as in the example below:

``` r
library(mlr3pipelines)
graph = Graph$new()
graph$add_pipeop(po("pca"))
graph$add_pipeop(po("pca"))
#> Error: PipeOp with id 'pca' already in Graph
```

After this PR, the function call is included, leading to improved error messages:

``` r
graph = Graph$new()
graph$add_pipeop(po("pca"))
graph$add_pipeop(po("pca"))
#> Error in graph$add_pipeop(po("pca")): PipeOp with id 'pca' already in Graph
```

*Note*: When calculating the call, we skip leanified calls, so the user does not see `Error in .__Graph__add_pipeop(self = self, private = private, super = super, po("pca")` and instead sees `Error in graph$add_pipeop(po("pca"))` as in the example above.

Furthermore, we now also included the `mlr3{error, warning}` class (but keep the inheritance from `simpleWarning` and `simpleError` for backwards compatibility) and add the `class` argument to `{stop, message, warning}f` which allows to give each condition its own error class.

This gives the user the control to disable specific conditions by registering `globalCallingHandler`s.

When an `mlr3` function throws such errors (that the user might want to disable), these should be listed in a section *Errors and Warnings* in the roxygen documentation.


TODOs:
* [ ] Add wiki entry after merging this.