### PR TITLE
perf(rcbind): use `%in%` instead of `intersect()` for name check

### DIFF
--- a/R/rcbind.R
+++ b/R/rcbind.R
@@ -30,12 +30,13 @@ rcbind = function(x, y) {
     stopf("Tables have different number of rows (x: %i, y: %i)", nrow(x), nrow(y))
   }
 
-  dup = intersect(names(x), names(y))
+  nn = names(y)
+  dup = nn[nn %in% names(x)]
   if (length(dup)) {
     stopf("Duplicated names: %s", str_collapse(dup))
   }
 
   # nolint next
   ..y = NULL
-  x[, (names(y)) := ..y][]
+  x[, (nn) := ..y][]
 }


### PR DESCRIPTION
Isolated name-check (`bench::mark`, 50 000 iterations):

  | cols (x / y) | `intersect()` | `ny[ny %in% nx]` | speedup | memory (old → new) |
  | ------------ | ------------: | ---------------: | ------: | -----------------: |
  | 5 / 3        |        9.39µs |            779ns |    ~12x |        0 B → 0 B   |
  | 20 / 10      |        10.4µs |            984ns |    ~11x |    720 B → 512 B   |
  | 100 / 20     |        12.1µs |            1.6µs |     ~8x |  5.5 KB → 2.1 KB   |
  | 500 / 50     |        20.8µs |            5.3µs |     ~4x |   22 KB → 9.2 KB   |
