### PR TITLE
perf: use setDT() inside map_dtc() call

### DIFF
--- a/R/purrr_map.R
+++ b/R/purrr_map.R
@@ -124,10 +124,15 @@ map_dtr = function(.x, .f, ..., .fill = FALSE, .idcol = NULL) {
 #' @export
 #' @rdname compat-map
 map_dtc = function(.x, .f, ...) {
-  cols = map(.x, .f, ...)
-  j = map_lgl(cols, function(x) !is.null(dim(x)) && !is.null(colnames(x)))
-  names(cols)[j] = ""
-  do.call(data.table, c(cols, list(check.names = TRUE)))
+  cols = compact(map(.x, .f, ...))
+  j = map_lgl(cols, function(x) !is.null(dim(x)))
+  if (any(j)) {
+    names(cols)[j] = ""
+    cols[j] = lapply(cols[j], function(x) if (is.data.frame(x)) x else as.data.frame(x))
+    cols[!j] = lapply(cols[!j], list)
+    cols = unlist(cols, recursive = FALSE)
+  }
+  setDT(cols, check.names = TRUE)[]
 }
 
 


### PR DESCRIPTION
closes: https://github.com/mlr-org/mlr3misc/issues/78, see the following:

  | input                              | old (do.call) | new (setDT) |
  | ---------------------------------- | ------------: | ----------: |
  | `runif(1e6, max = x)`              |         30 ms |       20 ms |
  | `data.table(x = runif(1e6, ...))`  |         23 ms |       19 ms |

`bench::mark` medians, iterations sized per case for stability:

  | case                               | main (do.call) | new (setDT) | speedup | main mem | new mem |
  | ---------------------------------- | -------------: | ----------: | ------: | -------: | ------: |
  | vectors (10 × 1000 rows)           |         157 µs |     89.3 µs |   1.76x |   178 KB |   95 KB |
  | small dt (10 × 100 rows)           |         624 µs |      344 µs |   1.81x |   209 KB |  194 KB |
  | medium dt (10 × 10 000 rows)       |        1.24 ms |      889 µs |   1.40x |  2.47 MB |  1.7 MB |
  | large dt (3 × 1 000 000 rows)      |        21.5 ms |     18.2 ms |   1.18x |  68.7 MB | 45.8 MB |
  | wide dt (5 × 100 cols × 1000 rows) |        4.84 ms |     2.21 ms |   2.19x |   228 KB |  207 KB |
  | mixed atomic + data.table          |        83.4 µs |     39.9 µs |   2.09x |    32 KB |   16 KB |
  | matrix (5 × 100 cols × 1000 rows)  |        7.72 ms |      4.4 ms |   1.75x |  17.5 MB | 13.5 MB |