### PR TITLE
perf(compute_mode): drop data.table overhead

### DIFF
--- a/R/compute_mode.R
+++ b/R/compute_mode.R
@@ -20,5 +20,6 @@ compute_mode = function(x, ties_method = "random", na_rm = TRUE) {
   if (na_rm) {
     x = x[!is.na(x)]
   }
-  as.data.table(x)[, .N, by = list(x)][which_max(get("N"), ties_method = ties_method)]$x
+  u = unique(x)
+  u[which_max(tabulate(match(x, u)), ties_method = ties_method)]
 }

--- a/R/compute_mode.R
+++ b/R/compute_mode.R
@@ -20,5 +20,12 @@ compute_mode = function(x, ties_method = "random", na_rm = TRUE) {
   if (na_rm) {
     x = x[!is.na(x)]
   }
-  as.data.table(x)[, .N, by = list(x)][which_max(get("N"), ties_method = ties_method)]$x
+  u = unique(x)
+  # match factors on their integer codes to avoid conversion to character
+  counts = if (is.factor(x)) {
+    tabulate(match(as.integer(x), as.integer(u)), nbins = length(u))
+  } else {
+    tabulate(match(x, u), nbins = length(u))
+  }
+  u[which_max(counts, ties_method = ties_method)]
 }

--- a/tests/testthat/test_compute_mode.R
+++ b/tests/testthat/test_compute_mode.R
@@ -1,0 +1,31 @@
+test_that("compute_mode", {
+  expect_identical(compute_mode(c(1, 1, 1, 2, 2, 2, 3), ties_method = "first"), 1)
+  expect_identical(compute_mode(c(1, 1, 1, 2, 2, 2, 3), ties_method = "last"), 2)
+  expect_true(compute_mode(c(1, 1, 1, 2, 2, 2, 3), ties_method = "random") %in% c(1, 2))
+  expect_identical(compute_mode(c(5L, 5L, 1L), ties_method = "first"), 5L)
+  expect_identical(compute_mode(c("b", "a", "a", "b", "c"), ties_method = "first"), "b")
+  expect_identical(compute_mode(c(TRUE, TRUE, FALSE), ties_method = "first"), TRUE)
+
+  expect_identical(
+    compute_mode(factor(c("b", "a", "a"), levels = c("a", "b", "z")), ties_method = "first"),
+    factor("a", levels = c("a", "b", "z"))
+  )
+})
+
+test_that("compute_mode NA handling", {
+  expect_identical(compute_mode(c(NA, NA, 1), ties_method = "first"), 1)
+  expect_identical(compute_mode(c(NA, NA, 1), ties_method = "first", na_rm = FALSE), NA_real_)
+  expect_identical(compute_mode(c(NA, 1), ties_method = "first", na_rm = FALSE), NA_real_)
+  expect_identical(compute_mode(c(NA, 1), ties_method = "last", na_rm = FALSE), 1)
+})
+
+test_that("compute_mode on empty input", {
+  expect_identical(compute_mode(numeric(0), ties_method = "first"), numeric(0))
+  expect_identical(compute_mode(character(0), ties_method = "first"), character(0))
+  expect_identical(compute_mode(logical(0), ties_method = "random"), logical(0))
+  expect_identical(compute_mode(c(NA_real_, NA_real_), ties_method = "first"), numeric(0))
+  expect_identical(
+    compute_mode(factor(character(0), levels = "a"), ties_method = "first"),
+    factor(character(0), levels = "a")
+  )
+})


### PR DESCRIPTION
Benchmarks via `bench::mark` (2000 iterations, `ties_method = "first"`):

  | input        | old median | new median | speedup  |
  | ------------ | ---------- | ---------- | -------- |
  | int (n=100)  | 412µs      | 9.7µs      | **~42×** |
  | int (n=10k)  | 623µs      | 128µs      | ~4.9×    |
  | int (n=100k) | 1.62ms     | 1.17ms     | ~1.4×    |
  | chr (n=100)  | 423µs      | 9.0µs      | **~47×** |
  | chr (n=10k)  | 690µs      | 258µs      | ~2.7×    |
  | dbl (n=100k) | 2.76ms     | 1.87ms     | ~1.5×    |
