### PR TITLE
docs: redocument with roxygen2 8.0.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -111,4 +111,4 @@ Collate:
     'which_max.R'
     'with_package.R'
     'zzz.R'
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.0.0.9000


### PR DESCRIPTION
Regenerate man pages and NAMESPACE with `devtools::document()` using roxygen2 8.0.0.9000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)